### PR TITLE
Update action.yml Node12 version to16 for resolving deprecation warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,5 +25,5 @@ inputs:
     required: true
     default: "1000"
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
Update to Node.js 16 to resolve Node12 deprecation warnings
 Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: emilioschepis/wait-for-endpoint